### PR TITLE
feat: 챌린지 모집 후 차주 월요일에 자동 챌린지 trigger 스케쥴링

### DIFF
--- a/src/main/java/com/hana/DofarmingApplication.java
+++ b/src/main/java/com/hana/DofarmingApplication.java
@@ -2,8 +2,10 @@ package com.hana;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DofarmingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/hana/api/group/entity/Group.java
+++ b/src/main/java/com/hana/api/group/entity/Group.java
@@ -47,7 +47,8 @@ public class Group extends BaseEntity {
 
     @Column(nullable = false)
     @ColumnDefault("0")
-    private Integer status;
+    @Setter
+    private Integer status; // status 0 이면 진행 전, status 1 이면 대기 중, status 2 이면 진행 중
 
     @Transient
     @Setter

--- a/src/main/java/com/hana/api/group/service/GroupService.java
+++ b/src/main/java/com/hana/api/group/service/GroupService.java
@@ -87,6 +87,16 @@ public class GroupService {
                     .user(user)
                     .build();
             groupMemberRepository.save(groupMember);
+
+            int participantNumber = groupMemberRepository.countByGroupId(group.getId());
+
+            if (group.getGroupNumber() == participantNumber) {
+                group.setStatus(1);
+                groupRepository.save(group);
+
+                // 차주 월요일에 status를 2로 바꾸는 스케줄링
+                dynamicSchedulerService.scheduleStatusUpdate(group.getId());
+            }
             return 1;
 
         } catch (BaseException e) {

--- a/src/main/java/com/hana/api/group/service/GroupService.java
+++ b/src/main/java/com/hana/api/group/service/GroupService.java
@@ -10,6 +10,7 @@ import com.hana.api.groupMember.repository.GroupMemberRepository;
 import com.hana.api.user.entity.User;
 import com.hana.common.config.BaseException;
 import com.hana.common.config.BaseResponseStatus;
+import com.hana.common.scheduler.DynamicSchedulerService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,8 @@ public class GroupService {
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final DynamicSchedulerService dynamicSchedulerService;
+
 
 
     public Group createGroup(GroupRequestDto.GroupCreateReq request, UUID userCode) {
@@ -48,6 +51,14 @@ public class GroupService {
                 .build();
 
         groupRepository.save(group);
+
+        GroupMemberPK groupMemberPK = new GroupMemberPK(group.getId(), userCode);
+        GroupMember groupMember = GroupMember.builder()
+                .id(groupMemberPK)
+                .group(group)
+                .user(user)
+                .build();
+        groupMemberRepository.save(groupMember);
         return group;
     }
 

--- a/src/main/java/com/hana/common/scheduler/DynamicSchedulerService.java
+++ b/src/main/java/com/hana/common/scheduler/DynamicSchedulerService.java
@@ -1,0 +1,47 @@
+package com.hana.common.scheduler;
+
+import com.hana.api.group.entity.Group;
+import com.hana.api.group.repository.GroupRepository;
+import com.hana.common.config.BaseException;
+import com.hana.common.config.BaseResponseStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Date;
+
+@Service
+public class DynamicSchedulerService {
+
+    private final TaskScheduler taskScheduler;
+    private final GroupRepository groupRepository;
+
+    @Autowired
+    public DynamicSchedulerService(TaskScheduler taskScheduler, GroupRepository groupRepository) {
+        this.taskScheduler = taskScheduler;
+        this.groupRepository = groupRepository;
+    }
+
+    public void scheduleStatusUpdate(long groupId) {
+        // 현재로부터 차주 월요일을 계산
+        LocalDateTime nextMonday = LocalDateTime.now()
+                .with(TemporalAdjusters.next(DayOfWeek.MONDAY))
+                .withHour(0)
+                .withMinute(0)
+                .withSecond(0);
+
+        // 스케줄링할 작업 정의
+        Runnable task = () -> {
+            Group group = groupRepository.findById(groupId).orElseThrow(() -> new BaseException(BaseResponseStatus.GROUPS_EMPTY_GROUP_ID));
+            group.setStatus(2);
+            groupRepository.save(group);
+        };
+
+        // 차주 월요일에 작업 스케줄링
+        Date scheduleDate = Date.from(nextMonday.atZone(java.time.ZoneId.systemDefault()).toInstant());
+        taskScheduler.schedule(task, scheduleDate);
+    }
+}

--- a/src/main/java/com/hana/common/scheduler/TaskSchedulerConfig.java
+++ b/src/main/java/com/hana/common/scheduler/TaskSchedulerConfig.java
@@ -1,0 +1,19 @@
+package com.hana.common.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class TaskSchedulerConfig {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 스레드 풀 크기 설정
+        scheduler.setThreadNamePrefix("scheduled-task-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}


### PR DESCRIPTION
### PR Type
- [x] 기능 개발 (Feature)
- [x] 버그수정 (Bugfix)

## 작업 내용
- closes #25 
- closes #11 

## 참고 사항, 첨부 자료 등
- 챌린지 모집 인원과 참여인원이 같을 시 챌린지 대기 상태로 변환
- 10초간은 챌린지 시작 대기 상태이므로 status 1로 변경함
- 10초 뒤 스케쥴링을 통해 챌린지 방 status 상태를 2로 변경하는 것을 테스트
- 실제 코드로는 차주 월요일 오전 12시에 실행되도록 구현
<img width="941" alt="스크린샷 2024-07-01 오후 4 19 41" src="https://github.com/Do-Farming/Do-Farming_Back/assets/69382168/a32c0607-cd47-49c8-9eb8-a21ba695843b">

